### PR TITLE
chore: Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+*.pyc
+*.egg-info
+*.swp
+tags
+node_modules
+__pycache__
+dist


### PR DESCRIPTION
Without this, "untracked" files exist on dev/prod machines - pycaches, dist, egg-info, etc